### PR TITLE
added check for multitask models

### DIFF
--- a/dnn/predict/insilicoSaturationMutagenesis/predictVariantsWithInsilicoSaturationMutagenesis.py
+++ b/dnn/predict/insilicoSaturationMutagenesis/predictVariantsWithInsilicoSaturationMutagenesis.py
@@ -193,6 +193,8 @@ def cli(regions_file, model_file, weights_file, reference_file, genome_file, alt
                             satMutSequence.getSequence()))
                     # predict
                     prediction = model.predict(np.array(X))
+                    if isinstance(prediction, list):
+                        prediction = np.column_stack(prediction)
                     n_tasks = np.shape(prediction)[1]
 
                     # initialize write once


### PR DESCRIPTION
Added a small check for DL models with multiple separate outputs. Checks if output is a list (of arrays) instead of an array.